### PR TITLE
Travis cache fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: generic
 cache:
+  timeout: 360
   directories:
   - "$HOME/.stack/"
   - "$HOME/.local/bin/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,20 @@ cache:
   - "$HOME/.stack/"
   - "$HOME/.local/bin/"
   - ".stack-work/"
-before_install:
+install:
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-install:
-- stack --no-terminal build -j 1 Cabal
-- stack --no-terminal test --only-dependencies
+
 jobs:
   include:
-    - stage: stack test and build site
-      script:
-        - stack --no-terminal test
-        - stack exec site rebuild
+    - stage: install cabal
+      script: stack --no-terminal build -j 1 Cabal
+    - stage: install pandoc
+      script: stack --no-terminal build pandoc
+    - stage: install deprndences
+      script: stack --no-terminal test --only-dependencies
+    - stage: stack test
+      script: stack --no-terminal test
+    - stage: rebuild site
+    - script: stack exec site rebuild


### PR DESCRIPTION
キャシュはステージごとに保存されるので、
ステージを分割することでステージごとのキャッシュを減らし、
更にタイムアウトの時間を180から360に増やすことで、
タイムアウトによるキャシュが反映されない問題を解決しました。