### PR TITLE
Move openssl command to deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
       if: branch = master AND type IN (push)
       script: stack exec site rebuild
       after_success:
+      - openssl aes-256-cbc -K $encrypted_90007859edaf_key -iv $encrypted_90007859edaf_iv -in deploy_key.enc -out deploy_key -d
       - eval "$(ssh-agent -s)"
       - chmod 600 deploy_key
       - ssh-add deploy_key
@@ -35,6 +36,4 @@ jobs:
       - git add -A
       - "git commit -m \"by Travis CI (JOB $TRAVIS_JOB_NUMBER) : $TRAVIS_COMMIT_MESSAGE\""
       - git push origin site
-before_install:
-- openssl aes-256-cbc -K $encrypted_90007859edaf_key -iv $encrypted_90007859edaf_iv
-  -in deploy_key.enc -out deploy_key -d
+


### PR DESCRIPTION
openssl コマンドが before install にあり、このコマンドで権限を持つユーザしか扱えない変数があるので fork したリポジトリからだと Travis でエラーになってしまうので、 deploy ステージに移すことによりそれを回避しました。
