### PR TITLE
resolver update 時のエラーを修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     - stage: install cabal
       script: stack --no-terminal build -j 1 Cabal
     - stage: install pandoc
-      script: stack --no-terminal build pandoc
+      script: travis_wait 30 stack --no-terminal build pandoc
     - stage: install deprndences
       script: stack --no-terminal test --only-dependencies
     - stage: stack test


### PR DESCRIPTION
pandoc のインストール時にタイムアウトが起こっていたので travis_wait を使って回避しました。
デフォルトでのタイムアウト時間は10分で、 travis_wait をつけると20分になるみたいです。