### PR TITLE
CircleCI キャッシュ修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,33 +6,35 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
-      - run:
-          name: Build docker image
-          command: |
-            rsync -ave --exclude='.circleci' ./ .circleci/code
-            docker-compose -f .circleci/docker-compose.yml build --build-arg resolver=$(cat stack.yaml | sed -n '/resolver:/p' | sed -r 's/resolver:\s(.*)/\1/') app
       - restore_cache:
           keys:
             - stack-{{ .Environment.COMMON_CACHE_KEY }}-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
             - stack-{{ .Environment.COMMON_CACHE_KEY }}-{{ checksum "stack.yaml" }}-
             - stack-{{ .Environment.COMMON_CACHE_KEY }}-
+      - run:
+          name: Build docker image
+          command: |
+            rsync -ave --exclude='.circleci' ./ .circleci/code
+            docker-compose -f .circleci/docker-compose.yml build --build-arg resolver=$(cat stack.yaml | sed -n '/resolver:/p' | sed -r 's/resolver:\s(.*)/\1/') app
+      - save_cache:
+          key: stack-{{ .Environment.COMMON_CACHE_KEY }}-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+          paths:
+            - .circleci/code/.stack-work
+      - restore_cache:
+          keys:
             - stack-{{ .Environment.COMMON_CACHE_KEY_SCRIPT }}-{{ checksum "./.circleci/build.hs" }}-{{ checksum "./.circleci/preview.hs" }}
             - stack-{{ .Environment.COMMON_CACHE_KEY_SCRIPT }}-{{ checksum "./.circleci/build.hs" }}-
             - stack-{{ .Environment.COMMON_CACHE_KEY_SCRIPT }}-
       - run:
           name: build when PR
           command: |
-            curl -sSL https://get.haskellstack.org/ | sh -s
+            curl -sSL https://get.haskellstack.org/ | sh -s - -f
             ./.circleci/build.hs
       - store_artifacts:
           path: _site
       - run:
           name: Send Artifacts URL to GitHub when PR
           command: ./.circleci/preview.hs
-      - save_cache:
-          key: stack-{{ .Environment.COMMON_CACHE_KEY }}-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
-          paths:
-            - .circleci/code/.stack-work
       - save_cache:
           key: stack-{{ .Environment.COMMON_CACHE_KEY_SCRIPT }}-{{ checksum "./.circleci/build.hs" }}-{{ checksum "./.circleci/preview.hs" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: build when PR
           command: |
-            curl -sSL https://get.haskellstack.org/ | sh -s - -f
+            curl -sSL https://get.haskellstack.org/ | sh -s
             ./.circleci/build.hs
       - store_artifacts:
           path: _site


### PR DESCRIPTION
`-f` を消したことにより毎回 `stack` が上書きされる問題を解決しました。