### PR TITLE
Windows でも build できるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ TODO.md
 haskell-blog.cabal
 *~
 _site
+css/*.css
+css/*.css.map
+.sass-cache

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ Fusce tortor quam, egestas in posuere quis, porttitor vel turpis...
 
 Proin vulputate sapien facilisis leo ornare pulvinar...
 ```
+
+### Build on Windows
+
+can't build `hakyll-sass`.
+So, build css on local using `sass`.
+
+```
+$ sass -I sass --scss ./css/main.scss ./css/main.css
+```

--- a/package.yaml
+++ b/package.yaml
@@ -17,8 +17,12 @@ dependencies:
 - stm
 - mtl
 - conduit-combinators
-- hakyll-sass
 - yaml
+
+when:
+  - condition: "!(os(windows))"
+    dependencies:
+    - hakyll-sass
 
 executables:
   site:

--- a/site.hs
+++ b/site.hs
@@ -1,10 +1,15 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 import qualified Config          as C
 import           Data.List       (stripPrefix)
 import           Data.Maybe
 import           Data.Monoid     ((<>))
 import           Hakyll
+
+#if !(defined(mingw32_HOST_OS))
 import           Hakyll.Web.Sass (sassCompiler)
+#endif
 
 main :: IO ()
 main = do
@@ -17,9 +22,15 @@ main' siteConfig = hakyllWith hakyllConfig $ do
     route idRoute
     compile copyFileCompiler
 
+#ifdef mingw32_HOST_OS
+  match "css/*.css" $ do
+    route idRoute
+    compile compressCssCompiler
+#else
   match "css/*.scss" $ do
     route $ setExtension "css"
     compile (fmap compressCss <$> sassCompiler)
+#endif
 
 -- TODO:watchで反映されない件byやまだ
   match (fromGlob "pages/**.md") $ do


### PR DESCRIPTION
戦犯は `hakyll-sass`
なので、Windows では `sass` を使って自前でビルドしてください。
`CPP` 拡張を使って切り換えてるので、非Windows は今まで通り使えるはず。