### PR TITLE
間違ったArtifactのURLが送られる問題の修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     machine:
       docker_layer_caching: true
+    working_directory: ~/haskell-blog
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
以前は `working_directory` を設定していましたが、キャッシュの修正をしたときに間違えて消してしまったみたいです.