### PR TITLE
feed が壊れてるので修正

### DIFF
--- a/posts/2018/08-21-path-and-path-io.md
+++ b/posts/2018/08-21-path-and-path-io.md
@@ -1,5 +1,5 @@
 ---
-title: path & path-io パッケージ
+title: path ＆ path-io パッケージ
 author: Shinya Yamaguchi
 tags: bigmoon, package
 ---


### PR DESCRIPTION
タイトルの & はエスケープされないため、https://haskell.e-bigmoon.com/feed.xml が壊れてます。
なので対処療法的に & を全角の ＆ に変更して欲しい。